### PR TITLE
Drive idle sessions via claude --resume --print

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ It isn't:
 1. A general-purpose webhook router — Telegram is the only target.
 2. A retry / circuit-breaker framework — per-slug throttle covers the spam case; transient API failures are logged and dropped.
 3. A daemon you run on a remote host — MCP binds to loopback only; assume the same machine as Claude Code.
-4. A multiplexer or keystroke-injection shim — the user's terminal stays sovereign. Inbound replies enter sessions only via Claude Code hook return values (see "Bidirectional design" below).
+4. A multiplexer / GUI / keystroke-injection shim into a *running* terminal. Belfry never types into your active terminal. For idle sessions it spawns a parallel `claude --resume` against the same on-disk transcript — that's a programmatic Claude Code invocation, not a hijack of the user's terminal.
 
 ## Architecture
 
@@ -63,6 +63,9 @@ lib/router.js          — incoming Telegram update → (slug, queue, text)
 lib/poller.js          — Telegram getUpdates long-poll loop
 lib/mcp-server.js      — JSON-RPC over HTTP on 127.0.0.1, drain/peek tools
 lib/slug.js            — slug derivation (mirrors claudelike-bar's rules)
+lib/dispatcher.js      — picks inbox-vs-spawn based on dashboard status
+lib/session-resolver.js — find most-recent session uuid for a slug's cwd
+lib/runner.js          — spawn `claude --resume <id> --print …` for idle drives
 hooks/stop-hook.js     — installable Stop hook (Phase 1)
 test/                  — node --test
 ```
@@ -71,11 +74,17 @@ Phase 2 will add `hooks/pre-tool-use-hook.js` (interrupt-and-replace) and an int
 
 ## Bidirectional design (binding spec for in-progress work)
 
-**Mechanism.** Replies enter sessions only through Claude Code hook return values. No keystroke injection, no terminal multiplexer.
+**Mechanism.** Two paths, picked at dispatch time by `lib/dispatcher.js` based on the slug's current dashboard status (`/tmp/claude-dashboard/<slug>.json`):
 
-1. **`Stop` hook → continuation.** Fires when Claude finishes a turn. The hook calls `mcp__belfry__drain_inbox(slug)`; if non-empty, returns `{"decision": "block", "reason": "<reply text>"}`. Claude Code resumes as if the user typed `<reply text>` at the prompt.
-2. **`PreToolUse` hook → interrupt-and-replace.** Fires before each tool call. Drains a separate "interrupt" inbox; if non-empty, returns `{"decision": "block", "reason": "<correction>"}`. Stops the tool and feeds the correction back as user feedback. Latency = "until the next tool call or Stop." Pure cancel is the degenerate case ("stop, wait a sec").
-3. **`Notification` hook → permission answer** (later phase). Same drain pattern, returns the reply as the answer to a permission prompt.
+1. **Active session (status: working/tool_end/notification/etc.) → hook drain.** The reply lands in the in-memory inbox; the next hook firing on that session drains it.
+   - `Stop` hook → continuation. Returns `{"decision":"block","reason":"<reply>"}` so Claude resumes as if the user typed `<reply>`.
+   - `PreToolUse` hook → interrupt-and-replace (Phase 2, #3). Drains a separate `interrupt` queue; returns the same shape to short-circuit the tool with user feedback.
+   - `Notification` hook → permission answer (Phase 3, #4). Same drain pattern.
+2. **Idle session (status: ready / missing JSON / error) → spawn-and-relay.** The dispatcher resolves the slug's most-recent session UUID via `lib/session-resolver.js` (newest `.jsonl` mtime under `~/.claude/projects/<encoded-cwd>/`) and runs `claude --resume <id> --print "<reply>"` from the slug's cwd via `lib/runner.js`. Stdout is sent back to the same Telegram chat so the user sees the answer on their phone without alt-tabbing to the terminal. The on-disk JSONL is shared with the user's terminal session — when they next interact, the spawned turn is already in history.
+
+Idle = `status === 'ready'` OR `status === 'error'` OR no dashboard JSON. Anything else is treated as active (the session is mid-conversation; a parallel spawn would race the same JSONL).
+
+**Why two paths.** Spawning into an active session creates a JSONL race; the hook drain avoids that by piggybacking on the existing turn. Hook drain into an idle session is a no-op forever; spawning lights it back up. Each path covers what the other can't.
 
 **Inbox semantics.**
 1. Multiple replies for one slug between drains **concatenate** into a single prompt (separator: blank line). They're treated as one thought sent in pieces.

--- a/bin/belfry.js
+++ b/bin/belfry.js
@@ -10,6 +10,9 @@ import { Inbox } from '../lib/inbox.js';
 import { ReplyTracker } from '../lib/reply-tracker.js';
 import { McpServer } from '../lib/mcp-server.js';
 import { Poller } from '../lib/poller.js';
+import { Dispatcher } from '../lib/dispatcher.js';
+import { runClaude } from '../lib/runner.js';
+import { resolveSession } from '../lib/session-resolver.js';
 
 function log(msg) {
   process.stderr.write(`${new Date().toISOString()} ${msg}\n`);
@@ -60,12 +63,26 @@ async function main() {
   const mcp = new McpServer({ inbox, port: mcpPort, log });
   await mcp.start();
 
+  // Dispatcher: smart push() that picks inbox-vs-spawn based on dashboard
+  // status. Quacks like Inbox so Poller doesn't know which path it took.
+  const dispatcher = new Dispatcher({
+    inbox,
+    runner: runClaude,
+    sessionResolver: resolveSession,
+    subscriptions: config.subscriptions,
+    sendReply: async ({ slug, text }) => {
+      const result = await sendMessage({ botToken, chatId, text, forumTopicId });
+      if (result?.message_id) replyTracker.record(result.message_id, slug);
+    },
+    log,
+  });
+
   const poller = new Poller({
     botToken,
     expectedChatId: Number(chatId),
     replyTracker,
     knownSlugs,
-    inbox,
+    inbox: dispatcher,
     log,
   });
   poller.start();

--- a/docs/belfry.jsonc.example
+++ b/docs/belfry.jsonc.example
@@ -12,6 +12,15 @@
     },
     "financial-planner": {
       "events": ["ready"]
+    },
+    // Optional: explicit cwd. Used to (a) resolve the most-recent session id
+    // under ~/.claude/projects/<encoded-cwd>/ and (b) as the working dir for
+    // `claude --resume <id> --print "<reply>"` when a Telegram reply lands
+    // on an idle session. Defaults to /workspace/projects/<slug>; override
+    // when the slug name and the project directory don't match.
+    "vault-direct": {
+      "events": ["ready"],
+      "cwd": "/workspace/projects/vault-direct"
     }
   },
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,6 +9,7 @@ const DEFAULT_PROMPT_CAP = 200;
 const DEFAULT_RESPONSE_CAP = 400;
 const DEFAULT_EVENTS = ['ready'];
 const VALID_EVENTS = new Set(['ready', 'error', 'waiting']);
+const DEFAULT_CWD_ROOT = '/workspace/projects';
 
 function stripJsonc(text) {
   // Drop // line comments and /* block comments */ before JSON.parse.
@@ -69,7 +70,15 @@ export function loadConfig(configPath = DEFAULT_CONFIG_PATH) {
       ? sub.events.filter((e) => VALID_EVENTS.has(e))
       : DEFAULT_EVENTS;
     if (events.length === 0) continue;
-    subscriptions[slug] = { events };
+    // cwd: where the slug's Claude Code session runs. Used to resolve the
+    // session id (most-recent jsonl in ~/.claude/projects/<encoded-cwd>/)
+    // and as the cwd of the spawned `claude --resume` subprocess for idle
+    // sessions. Defaults to /workspace/projects/<slug> — covers every slug
+    // currently in this workspace except the ones with spaces.
+    const cwd = typeof sub?.cwd === 'string' && sub.cwd.length > 0
+      ? sub.cwd
+      : path.join(DEFAULT_CWD_ROOT, slug);
+    subscriptions[slug] = { events, cwd };
   }
   return {
     subscriptions,

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -1,0 +1,124 @@
+/**
+ * Decide what to do with an inbound Telegram reply.
+ *
+ * Old design (Phase 1, pre-idle-fix): every routed message went straight to
+ * an in-memory inbox; the Stop hook drained it at the next turn boundary.
+ * That works while a session is mid-conversation but breaks the moment the
+ * session goes idle — Stop never fires again, the reply rots in the inbox.
+ *
+ * New design: dispatcher reads the slug's dashboard JSON
+ * (`/tmp/claude-dashboard/<slug>.json`) to decide:
+ *   - status === 'working' → push to inbox; the Stop hook will drain it at
+ *     the end of the in-flight turn.
+ *   - anything else (ready, error, missing, parse fail) → spawn
+ *     `claude --resume <session-id> --print "<reply>"` in the slug's cwd.
+ *     Capture stdout, send back to Telegram so the user sees the answer
+ *     without needing to alt-tab to the terminal.
+ *
+ * Quacks like an Inbox for the `push(slug, queue, text)` shape — the Poller
+ * doesn't need to know which path will be taken. Returns a Promise so a
+ * caller can await if needed; the Poller fires-and-forgets.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export class Dispatcher {
+  constructor({
+    inbox,
+    runner,
+    sessionResolver,
+    subscriptions,
+    dashboardDir = '/tmp/claude-dashboard',
+    sendReply,
+    log = () => {},
+    fsImpl = fs,
+  }) {
+    this.inbox = inbox;
+    this.runner = runner;
+    this.sessionResolver = sessionResolver;
+    this.subscriptions = subscriptions;
+    this.dashboardDir = dashboardDir;
+    this.sendReply = sendReply;
+    this.log = log;
+    this.fsImpl = fsImpl;
+  }
+
+  /**
+   * Mirror of Inbox#push. Interrupt queue is unconditionally inboxed —
+   * interrupts only make sense mid-tool-call, so the active session
+   * assumption is intrinsic. Continuation goes through the smart path.
+   */
+  push(slug, queue, text) {
+    if (queue !== 'continuation') {
+      this.inbox.push(slug, queue, text);
+      return Promise.resolve();
+    }
+    return this.dispatchContinuation(slug, text);
+  }
+
+  async dispatchContinuation(slug, text) {
+    const status = this.readDashboardStatus(slug);
+    // 'ready' = turn finished, session is idle waiting for the next prompt.
+    // Everything else (working, tool_end, notification, etc.) means the
+    // session is mid-conversation; the Stop hook will fire and drain the
+    // inbox at the next turn boundary, so push there.
+    // Missing JSON / error: treat as idle and let the spawn path try.
+    const idle = status === 'ready' || status === null || status === 'error';
+    if (!idle) {
+      this.inbox.push(slug, 'continuation', text);
+      this.log(`dispatcher: ${slug} active (status=${status}) — pushed to inbox (${text.length} chars)`);
+      return;
+    }
+
+    const sub = this.subscriptions[slug];
+    if (!sub?.cwd) {
+      this.log(`dispatcher: ${slug} has no cwd configured — falling back to inbox`);
+      this.inbox.push(slug, 'continuation', text);
+      return;
+    }
+
+    const sessionId = this.sessionResolver(sub.cwd);
+    this.log(`dispatcher: spawning claude for ${slug} (status=${status ?? 'missing'}, session=${sessionId ?? 'fresh'})`);
+
+    let result;
+    try {
+      result = await this.runner({ prompt: text, cwd: sub.cwd, sessionId });
+    } catch (err) {
+      this.log(`dispatcher: runner threw for ${slug}: ${err.message}`);
+      await this.safeReply(slug, `⚠ belfry could not drive ${slug}: ${err.message}`);
+      return;
+    }
+
+    if (result.ok && result.stdout) {
+      this.log(`dispatcher: ${slug} returned ${result.stdout.length} chars; relaying to telegram`);
+      await this.safeReply(slug, result.stdout);
+      return;
+    }
+
+    const reason = result.timedOut
+      ? 'timed out (60s)'
+      : (result.stderr || `exit ${result.code}`).slice(0, 300);
+    this.log(`dispatcher: claude run failed for ${slug}: ${reason}`);
+    await this.safeReply(slug, `⚠ belfry could not drive ${slug}: ${reason}`);
+  }
+
+  readDashboardStatus(slug) {
+    try {
+      const raw = this.fsImpl.readFileSync(path.join(this.dashboardDir, `${slug}.json`), 'utf8');
+      const json = JSON.parse(raw);
+      return typeof json.status === 'string' ? json.status : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async safeReply(slug, text) {
+    if (!this.sendReply) return;
+    try {
+      await this.sendReply({ slug, text });
+    } catch (err) {
+      this.log(`dispatcher: telegram reply failed for ${slug}: ${err.message}`);
+    }
+  }
+}

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -135,8 +135,12 @@ export class Poller {
       knownSlugs: this.knownSlugs,
     });
     if (!routed) return;
-    this.inbox.push(routed.slug, routed.queue, routed.text);
-    this.log(`inbox push ${routed.slug}/${routed.queue} (${routed.text.length} chars)`);
+    // .push may be async on the dispatcher path (spawn-and-reply) — fire and
+    // forget; the dispatcher catches its own errors so the poller keeps moving.
+    Promise.resolve(this.inbox.push(routed.slug, routed.queue, routed.text)).catch((err) => {
+      this.log(`dispatch failed for ${routed.slug}: ${err.message}`);
+    });
+    this.log(`routed ${routed.slug}/${routed.queue} (${routed.text.length} chars)`);
   }
 }
 

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,0 +1,86 @@
+/**
+ * Run a one-shot Claude Code turn programmatically.
+ *
+ * Used to drive a session that has no live terminal attached. The Stop hook
+ * only fires when Claude finishes a turn — useless for a fully idle session
+ * — so when a Telegram reply arrives for an idle slug, belfry spawns
+ *
+ *   claude --resume <session-id> --print "<reply>"
+ *
+ * in the slug's cwd. The subprocess writes one turn into the same JSONL
+ * transcript the user was last using, so when they look at the terminal
+ * later the conversation has progressed naturally.
+ *
+ * No session id → fresh session via `claude --print "<reply>"`. The reply
+ * lands as the first user prompt; the spawned turn becomes a brand-new
+ * jsonl and on next start the session-resolver finds it.
+ *
+ * Output: { ok, stdout, stderr, code, timedOut }. Caller decides what to
+ * relay back to Telegram.
+ */
+
+import { spawn as nodeSpawn } from 'node:child_process';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_BIN = 'claude';
+
+export async function runClaude({
+  prompt,
+  cwd,
+  sessionId = null,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  bin = DEFAULT_BIN,
+  spawnImpl = nodeSpawn,
+} = {}) {
+  if (typeof prompt !== 'string' || prompt.length === 0) {
+    return { ok: false, stdout: '', stderr: 'empty prompt', code: null, timedOut: false };
+  }
+  if (typeof cwd !== 'string' || cwd.length === 0) {
+    return { ok: false, stdout: '', stderr: 'missing cwd', code: null, timedOut: false };
+  }
+
+  const args = ['--print'];
+  if (sessionId) args.push('--resume', sessionId);
+  args.push(prompt);
+
+  return await new Promise((resolve) => {
+    let child;
+    try {
+      child = spawnImpl(bin, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    } catch (err) {
+      resolve({ ok: false, stdout: '', stderr: err.message, code: null, timedOut: false });
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      // Give it 2s to die gracefully, then SIGKILL.
+      setTimeout(() => child.kill('SIGKILL'), 2000).unref();
+    }, timeoutMs);
+    timer.unref();
+
+    child.stdout?.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr?.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({ ok: false, stdout, stderr: stderr || err.message, code: null, timedOut });
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({
+        ok: code === 0 && !timedOut,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        code,
+        timedOut,
+      });
+    });
+  });
+}

--- a/lib/session-resolver.js
+++ b/lib/session-resolver.js
@@ -1,0 +1,50 @@
+/**
+ * Resolve the most-recent Claude Code session UUID for a given cwd.
+ *
+ * Claude Code stores per-session JSONL transcripts at
+ * `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. Encoding rule
+ * (verified for /workspace/projects/<slug> paths): every `/` and `.` in the
+ * absolute cwd is replaced with `-`. So `/workspace/projects/belfry` →
+ * `-workspace-projects-belfry`.
+ *
+ * "Most recent" = highest mtime among `.jsonl` files in that dir. We use the
+ * UUID to pass to `claude --resume <id>` so a Telegram reply lands in the
+ * same conversation the user was last having.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const DEFAULT_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
+
+export function encodeCwd(cwd) {
+  return cwd.replace(/[/.]/g, '-');
+}
+
+export function resolveSession(cwd, { fsImpl = fs, projectsDir = DEFAULT_PROJECTS_DIR } = {}) {
+  if (typeof cwd !== 'string' || cwd.length === 0) return null;
+  const dir = path.join(projectsDir, encodeCwd(cwd));
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(dir);
+  } catch {
+    return null;
+  }
+  let bestId = null;
+  let bestMtime = -Infinity;
+  for (const entry of entries) {
+    if (!entry.endsWith('.jsonl')) continue;
+    let stat;
+    try {
+      stat = fsImpl.statSync(path.join(dir, entry));
+    } catch {
+      continue;
+    }
+    if (stat.mtimeMs > bestMtime) {
+      bestMtime = stat.mtimeMs;
+      bestId = entry.slice(0, -'.jsonl'.length);
+    }
+  }
+  return bestId;
+}

--- a/lib/telegram.js
+++ b/lib/telegram.js
@@ -5,7 +5,7 @@
  * is out of scope for an outbound-only relay.
  */
 
-export async function sendMessage({ botToken, chatId, text, forumTopicId }) {
+export async function sendMessage({ botToken, chatId, text, forumTopicId, replyToMessageId }) {
   const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
   const body = {
     chat_id: chatId,
@@ -14,6 +14,9 @@ export async function sendMessage({ botToken, chatId, text, forumTopicId }) {
   };
   if (forumTopicId) {
     body.message_thread_id = Number(forumTopicId);
+  }
+  if (replyToMessageId) {
+    body.reply_to_message_id = Number(replyToMessageId);
   }
   const res = await fetch(url, {
     method: 'POST',

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -59,6 +59,28 @@ test('drops invalid event names', () => {
   fs.unlinkSync(p);
 });
 
+test('subscription cwd defaults to /workspace/projects/<slug>', () => {
+  const p = tmp(`{
+    "subscriptions": {
+      "belfry": { "events": ["ready"] }
+    }
+  }`);
+  const cfg = loadConfig(p);
+  assert.equal(cfg.subscriptions.belfry.cwd, '/workspace/projects/belfry');
+  fs.unlinkSync(p);
+});
+
+test('subscription cwd can be overridden explicitly', () => {
+  const p = tmp(`{
+    "subscriptions": {
+      "x": { "events": ["ready"], "cwd": "/some/custom/path" }
+    }
+  }`);
+  const cfg = loadConfig(p);
+  assert.equal(cfg.subscriptions.x.cwd, '/some/custom/path');
+  fs.unlinkSync(p);
+});
+
 test('isSubscribed matches slug + event', () => {
   const cfg = {
     subscriptions: { 'a': { events: ['ready', 'error'] } },

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Dispatcher } from '../lib/dispatcher.js';
+import { Inbox } from '../lib/inbox.js';
+
+function makeFakeFs(files) {
+  return {
+    readFileSync(p) {
+      if (!(p in files)) {
+        const err = new Error(`ENOENT ${p}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return files[p];
+    },
+  };
+}
+
+function setup({
+  status = 'ready',
+  cwd = '/projects/belfry',
+  runnerResult = { ok: true, stdout: 'hello back', stderr: '', code: 0, timedOut: false },
+  sessionId = 'sess-1',
+} = {}) {
+  const inbox = new Inbox();
+  const sent = [];
+  const runnerCalls = [];
+  const log = () => {};
+  const dispatcher = new Dispatcher({
+    inbox,
+    runner: async (args) => {
+      runnerCalls.push(args);
+      return runnerResult;
+    },
+    sessionResolver: () => sessionId,
+    subscriptions: { belfry: { events: ['ready'], cwd } },
+    dashboardDir: '/dashboard',
+    sendReply: async ({ slug, text }) => { sent.push({ slug, text }); },
+    log,
+    fsImpl: makeFakeFs(
+      status === '__missing__'
+        ? {}
+        : { '/dashboard/belfry.json': JSON.stringify({ status }) }
+    ),
+  });
+  return { dispatcher, inbox, sent, runnerCalls };
+}
+
+test('working status → push to inbox, no spawn', async () => {
+  const { dispatcher, inbox, sent, runnerCalls } = setup({ status: 'working' });
+  await dispatcher.push('belfry', 'continuation', 'do thing');
+  assert.equal(inbox.peek('belfry', 'continuation'), 'do thing');
+  assert.equal(runnerCalls.length, 0);
+  assert.equal(sent.length, 0);
+});
+
+test('tool_end status → push to inbox (mid-tool, still active)', async () => {
+  const { dispatcher, inbox, sent, runnerCalls } = setup({ status: 'tool_end' });
+  await dispatcher.push('belfry', 'continuation', 'do thing');
+  assert.equal(inbox.peek('belfry', 'continuation'), 'do thing');
+  assert.equal(runnerCalls.length, 0);
+  assert.equal(sent.length, 0);
+});
+
+test('notification status → push to inbox (active, awaiting permission)', async () => {
+  const { dispatcher, inbox, sent, runnerCalls } = setup({ status: 'notification' });
+  await dispatcher.push('belfry', 'continuation', 'yes');
+  assert.equal(inbox.peek('belfry', 'continuation'), 'yes');
+  assert.equal(runnerCalls.length, 0);
+  assert.equal(sent.length, 0);
+});
+
+test('ready status → spawn claude --resume, relay output to telegram', async () => {
+  const { dispatcher, inbox, sent, runnerCalls } = setup({ status: 'ready' });
+  await dispatcher.push('belfry', 'continuation', 'do thing');
+  assert.equal(inbox.peek('belfry', 'continuation'), null);
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(runnerCalls[0].sessionId, 'sess-1');
+  assert.equal(runnerCalls[0].cwd, '/projects/belfry');
+  assert.equal(runnerCalls[0].prompt, 'do thing');
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].slug, 'belfry');
+  assert.equal(sent[0].text, 'hello back');
+});
+
+test('missing dashboard → spawn (treat as idle)', async () => {
+  const { dispatcher, inbox, sent, runnerCalls } = setup({ status: '__missing__' });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(sent.length, 1);
+  assert.equal(inbox.peek('belfry', 'continuation'), null);
+});
+
+test('error status → spawn (treat as idle)', async () => {
+  const { dispatcher, runnerCalls, sent } = setup({ status: 'error' });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(sent.length, 1);
+});
+
+test('runner returns ok=false → reply with error message', async () => {
+  const { dispatcher, sent } = setup({
+    status: 'ready',
+    runnerResult: { ok: false, stdout: '', stderr: 'boom', code: 1, timedOut: false },
+  });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(sent.length, 1);
+  assert.match(sent[0].text, /could not drive belfry/);
+  assert.match(sent[0].text, /boom/);
+});
+
+test('runner times out → reply with timeout note', async () => {
+  const { dispatcher, sent } = setup({
+    status: 'ready',
+    runnerResult: { ok: false, stdout: '', stderr: '', code: null, timedOut: true },
+  });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(sent.length, 1);
+  assert.match(sent[0].text, /timed out/);
+});
+
+test('no sessionId resolved → spawn fresh (no --resume)', async () => {
+  const { dispatcher, runnerCalls } = setup({ status: 'ready', sessionId: null });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(runnerCalls[0].sessionId, null);
+});
+
+test('interrupt queue always pushes to inbox, never spawns', async () => {
+  const { dispatcher, inbox, runnerCalls, sent } = setup({ status: 'ready' });
+  await dispatcher.push('belfry', 'interrupt', 'STOP');
+  assert.equal(inbox.peek('belfry', 'interrupt'), 'STOP');
+  assert.equal(runnerCalls.length, 0);
+  assert.equal(sent.length, 0);
+});
+
+test('subscription with no cwd configured → fallback to inbox', async () => {
+  const inbox = new Inbox();
+  const sent = [];
+  const runnerCalls = [];
+  const dispatcher = new Dispatcher({
+    inbox,
+    runner: async (args) => { runnerCalls.push(args); return { ok: true, stdout: 'ok' }; },
+    sessionResolver: () => 'sess-1',
+    subscriptions: { belfry: { events: ['ready'] } }, // no cwd
+    dashboardDir: '/dashboard',
+    sendReply: async (m) => { sent.push(m); },
+    log: () => {},
+    fsImpl: makeFakeFs({ '/dashboard/belfry.json': JSON.stringify({ status: 'ready' }) }),
+  });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(inbox.peek('belfry', 'continuation'), 'hi');
+  assert.equal(runnerCalls.length, 0);
+});
+
+test('runner throws → caught, reply sent, does not propagate', async () => {
+  const inbox = new Inbox();
+  const sent = [];
+  const dispatcher = new Dispatcher({
+    inbox,
+    runner: async () => { throw new Error('disk full'); },
+    sessionResolver: () => 'sess-1',
+    subscriptions: { belfry: { events: ['ready'], cwd: '/projects/belfry' } },
+    dashboardDir: '/dashboard',
+    sendReply: async (m) => { sent.push(m); },
+    log: () => {},
+    fsImpl: makeFakeFs({ '/dashboard/belfry.json': JSON.stringify({ status: 'ready' }) }),
+  });
+  await dispatcher.push('belfry', 'continuation', 'hi');
+  assert.equal(sent.length, 1);
+  assert.match(sent[0].text, /disk full/);
+});

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { runClaude } from '../lib/runner.js';
+
+function fakeSpawn({ stdout = '', stderr = '', code = 0, delayMs = 0, throwOnSpawn = false } = {}) {
+  let captured;
+  const spawnImpl = (bin, args, opts) => {
+    captured = { bin, args, opts };
+    if (throwOnSpawn) throw new Error('ENOENT');
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    setTimeout(() => {
+      if (stdout) child.stdout.emit('data', Buffer.from(stdout));
+      if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+      child.emit('close', code);
+    }, delayMs);
+    return child;
+  };
+  return { spawnImpl, getCaptured: () => captured };
+}
+
+test('runClaude with sessionId passes --resume <id>', async () => {
+  const { spawnImpl, getCaptured } = fakeSpawn({ stdout: 'hello back', code: 0 });
+  const result = await runClaude({
+    prompt: 'hi',
+    cwd: '/tmp',
+    sessionId: 'abc-123',
+    spawnImpl,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.stdout, 'hello back');
+  const { args, opts } = getCaptured();
+  assert.deepEqual(args, ['--print', '--resume', 'abc-123', 'hi']);
+  assert.equal(opts.cwd, '/tmp');
+});
+
+test('runClaude without sessionId omits --resume', async () => {
+  const { spawnImpl, getCaptured } = fakeSpawn({ stdout: 'fresh', code: 0 });
+  const result = await runClaude({ prompt: 'hi', cwd: '/tmp', spawnImpl });
+  assert.equal(result.ok, true);
+  assert.deepEqual(getCaptured().args, ['--print', 'hi']);
+});
+
+test('runClaude returns ok:false when exit code is non-zero', async () => {
+  const { spawnImpl } = fakeSpawn({ stderr: 'boom', code: 1 });
+  const result = await runClaude({ prompt: 'hi', cwd: '/tmp', spawnImpl });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 1);
+  assert.equal(result.stderr, 'boom');
+});
+
+test('runClaude rejects empty prompt', async () => {
+  const { spawnImpl } = fakeSpawn();
+  const result = await runClaude({ prompt: '', cwd: '/tmp', spawnImpl });
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /empty prompt/);
+});
+
+test('runClaude rejects missing cwd', async () => {
+  const { spawnImpl } = fakeSpawn();
+  const result = await runClaude({ prompt: 'hi', cwd: '', spawnImpl });
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /missing cwd/);
+});
+
+test('runClaude handles spawn throwing synchronously', async () => {
+  const { spawnImpl } = fakeSpawn({ throwOnSpawn: true });
+  const result = await runClaude({ prompt: 'hi', cwd: '/tmp', spawnImpl });
+  assert.equal(result.ok, false);
+  assert.match(result.stderr, /ENOENT/);
+});
+
+test('runClaude times out and reports timedOut=true', async () => {
+  const { spawnImpl } = fakeSpawn({ stdout: 'slow', code: 0, delayMs: 200 });
+  const result = await runClaude({ prompt: 'hi', cwd: '/tmp', spawnImpl, timeoutMs: 50 });
+  assert.equal(result.timedOut, true);
+  assert.equal(result.ok, false);
+});

--- a/test/session-resolver.test.js
+++ b/test/session-resolver.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { encodeCwd, resolveSession } from '../lib/session-resolver.js';
+
+test('encodeCwd replaces / and . with -', () => {
+  assert.equal(encodeCwd('/workspace/projects/belfry'), '-workspace-projects-belfry');
+  assert.equal(encodeCwd('/home/node/.claude/projects/x'), '-home-node--claude-projects-x');
+});
+
+function makeFakeFs({ dirs }) {
+  // dirs: { '/some/dir': [{ name: 'a.jsonl', mtimeMs: 100 }, ...] }
+  return {
+    readdirSync(d) {
+      if (!(d in dirs)) {
+        const err = new Error(`ENOENT: ${d}`);
+        err.code = 'ENOENT';
+        throw err;
+      }
+      return dirs[d].map((e) => e.name);
+    },
+    statSync(full) {
+      for (const [d, entries] of Object.entries(dirs)) {
+        for (const entry of entries) {
+          if (`${d}/${entry.name}` === full) return { mtimeMs: entry.mtimeMs };
+        }
+      }
+      const err = new Error(`ENOENT: ${full}`);
+      err.code = 'ENOENT';
+      throw err;
+    },
+  };
+}
+
+test('resolveSession returns most recent .jsonl uuid', () => {
+  const fsImpl = makeFakeFs({
+    dirs: {
+      '/projects/-workspace-projects-belfry': [
+        { name: 'old-session-id.jsonl', mtimeMs: 100 },
+        { name: 'newer-session-id.jsonl', mtimeMs: 200 },
+        { name: 'oldest-session-id.jsonl', mtimeMs: 50 },
+      ],
+    },
+  });
+  const id = resolveSession('/workspace/projects/belfry', { fsImpl, projectsDir: '/projects' });
+  assert.equal(id, 'newer-session-id');
+});
+
+test('resolveSession returns null when dir does not exist', () => {
+  const fsImpl = makeFakeFs({ dirs: {} });
+  const id = resolveSession('/no/such/path', { fsImpl, projectsDir: '/projects' });
+  assert.equal(id, null);
+});
+
+test('resolveSession returns null when dir has no .jsonl files', () => {
+  const fsImpl = makeFakeFs({
+    dirs: {
+      '/projects/-workspace-projects-belfry': [
+        { name: 'memory', mtimeMs: 100 },
+        { name: 'something.txt', mtimeMs: 200 },
+      ],
+    },
+  });
+  const id = resolveSession('/workspace/projects/belfry', { fsImpl, projectsDir: '/projects' });
+  assert.equal(id, null);
+});
+
+test('resolveSession ignores non-.jsonl entries when picking most recent', () => {
+  const fsImpl = makeFakeFs({
+    dirs: {
+      '/projects/-workspace-projects-belfry': [
+        { name: 'a.jsonl', mtimeMs: 100 },
+        { name: 'newer.txt', mtimeMs: 999 },
+      ],
+    },
+  });
+  const id = resolveSession('/workspace/projects/belfry', { fsImpl, projectsDir: '/projects' });
+  assert.equal(id, 'a');
+});
+
+test('resolveSession returns null for empty or non-string cwd', () => {
+  assert.equal(resolveSession('', { fsImpl: makeFakeFs({ dirs: {} }), projectsDir: '/projects' }), null);
+  assert.equal(resolveSession(null, { fsImpl: makeFakeFs({ dirs: {} }), projectsDir: '/projects' }), null);
+});


### PR DESCRIPTION
## Summary

Closes the gap where Phase 1 (#2) inbound replies only worked while the target session was mid-conversation — Stop never fires on a fully idle session, so the reply rotted forever. Adds a second dispatch path that spawns a programmatic Claude Code turn against the same on-disk transcript.

## Mechanism

- **`lib/dispatcher.js`** — quacks like `Inbox#push` for the Poller. Reads `/tmp/claude-dashboard/<slug>.json`. `status === 'ready' | 'error' | (missing)` → spawn. Anything else (`working`, `tool_end`, `notification`, ...) → inbox, so the active hook drain still owns it. Avoids JSONL races.
- **`lib/session-resolver.js`** — encodes cwd to `~/.claude/projects/<dir>/`, picks the highest-mtime `.jsonl`. That uuid feeds `--resume`.
- **`lib/runner.js`** — `spawn('claude', ['--print', '--resume', id, prompt], { cwd })`. 60s timeout, captures stdout, mockable for tests.
- **Config** — subscriptions accept an optional `cwd`, defaulting to `/workspace/projects/<slug>`.
- **CLAUDE.md** — terminal-sovereignty framing dropped; the new path explicitly spawns parallel `claude` processes. Hook drain remains the default for active sessions.

## What changed for the user

Reply on Telegram → idle session wakes up, runs the prompt, sends the answer back to the same chat. Active session still uses the existing Stop-hook path so a turn-in-progress isn't disturbed.

## Test plan

- [x] `npm test` — 104 tests, all green (3 new test files: 6 + 7 + 12 cases for session-resolver, runner, dispatcher)
- [x] Smoke: `runClaude` against the real `claude --print` binary returned a 5-word greeting (`{ ok: true, code: 0, stdout: 'Hi there, how are you?' }`)
- [x] Daemon restart with new code clean (logs show `mcp listening`, `poller started`, `belfry up`, `primed offset`)
- [ ] Live: Telegram reply to an idle slug triggers spawn-and-relay. **Verify after merge / on running daemon.**

## Out of scope

1. Haiku-summarized prompt/response (#7) — evaluated, recommended deferring until `last_response` actually renders (#5 sub-item 1)
2. Idle-resolution edge cases beyond "newest jsonl mtime" (e.g. forked sessions, archived projects) — current heuristic is sufficient for the workspace's slug → cwd mapping